### PR TITLE
data_to_json.rb use command-line args

### DIFF
--- a/data-utilities/data_to_json.rb
+++ b/data-utilities/data_to_json.rb
@@ -1,73 +1,99 @@
+#!/usr/bin/env ruby
+#
+# This script converts city data in csv format to json consumable by the webapp.
+# Use the script arguments to match the csv headers to the correct json keys.
+#
+# Sample call that uses some defaults:
+# ./data-utilities/data_to_json.rb \
+#   -i _src/data/fy2017/wichita_2017_adopted_budget.csv \
+#   -o _src/data/fy2017/wichita_2017_adopted_budget.json
+#
+# Sample call to map json keys to specific csv header names:
+# ./data-utilities/data_to_json.rb \
+#   -i _src/data/fy2017/wichita_2017_adopted_budget.csv \
+#   -o _src/data/fy2017/wichita_2017_adopted_budget.json \
+#   --agency=dept_title \
+#   --fund=org_cost_acct \
+#   --lob=oca_title \
+#   --program=obj_lvl_3_title \
+#   --key=obj_lvl_3_title \
+#   --value=appropriation_amt
+
 require 'csv'
 require 'json'
+require 'optparse'
 
-puts "Please supply the name of the file"
+options = {}
 
-file_name = gets.strip
-csv_file_name = "#{file_name}.csv"
+# Maybe sane defaults
+options[:fileout] = nil
+options[:agency] = 'dept_title'
+options[:fund] = 'org_cost_acct'
+options[:lob] = 'oca_title'
+options[:program] = 'obj_lvl_3_title'
+options[:key] = 'obj_lvl_3_title'
+options[:value] = 'appropriation_amt'
 
-csv = CSV.read(csv_file_name, headers: true)
+OptionParser.new do |opts|
+  opts.banner = "Usage: data_to_json.rb [options]"
+  opts.on('-i', '--inputfile filename', '') { |v| options[:filein] = v }
+  opts.on('-o', '--outputfile filename', '') { |v| options[:fileout] = v }
+  opts.on('-a', '--agency columnName', 'csv column representing the "agency"') { |v| options[:agency] = v }
+  opts.on('-f', '--fund columnName', 'csv column representing the "fund"') { |v| options[:fund] = v }
+  opts.on('-l', '--lob columnName', 'csv column representing the "lob"') { |v| options[:lob] = v }
+  opts.on('-p', '--program columnName', 'csv column representing the "program"') { |v| options[:program] = v }
+  opts.on('-k', '--key columnName', 'csv column representing the "key"') { |v| options[:key] = v }
+  opts.on('-v', '--value columnName', 'csv column representing the "value"') { |v| options[:value] = v }
+end.parse!
+
+if options[:filein] == nil || !File.file?(options[:filein])
+  raise "Input file does not exist"
+end
+
+# Note this encoding seems to work with utf8-bom and ascii files.
+csv = CSV.read(options[:filein], headers: true, encoding: 'bom|utf-8')
 headers = csv.headers
 
-p headers
+idx = {}
+idx[:obj_lvl_3_id] = 6
+idx[:agency] = headers.find_index(options[:agency])
+idx[:fund] = headers.find_index(options[:fund])
+idx[:lob] = headers.find_index(options[:lob])
+idx[:program] = headers.find_index(options[:program])
+idx[:key] = headers.find_index(options[:key])
+idx[:value] = headers.find_index(options[:value])
 
-puts "Please select the number corresponding to the agency:"
-headers.each_with_index { |header, index| puts "#{index}: #{header}"}
-
-agency = gets
-
-puts "Please select the number corresponding to the account:"
-headers.each_with_index { |header, index| puts "#{index}: #{header}"}
-
-account = gets
-
-puts "Please select the number corresponding to the fund:"
-headers.each_with_index { |header, index| puts "#{index}: #{header}"}
-
-fund = gets
-
-#puts "Please select the number corresponding to the operating unit:"
-#headers.each_with_index { |header, index| puts "#{index}: #{header}"}
-
-#operating_unit = gets
-
-puts "Please select the number corresponding to the operating lob:"
-headers.each_with_index { |header, index| puts "#{index}: #{header}"}
-
-lob = gets
-
-puts "Please select the number corresponding to the program name:"
-headers.each_with_index { |header, index| puts "#{index}: #{header}"}
-
-program_name = gets
-
-puts "Please select the number corresponding to the amount:"
-headers.each_with_index { |header, index| puts "#{index}: #{header}"}
-
-amount = gets
+idx.each do |k, v|
+  if v == nil || !(v.to_i >= 0 && v.to_i < headers.length)
+    raise "Json key #{k} does not match a header in csv. Validate input."
+  end
+end
 
 data = []
-csv.each do |row|
 
+csv.each do |row|
   # In the Wichita dataset, the `obj_lvl_3` column (which correlates to
   # "account" here) determines whether the line is revenue or an expenditure. If
   # it begins with 1-5, it's an expense, and 6-9 notates revenue.
-  obj_lvl_3_id = row[headers[6]]
-
+  #
   # Only collecting expenses here
-  next unless [1,2,3,4,5].include? obj_lvl_3_id[0].to_i
+  next unless [1,2,3,4,5].include? row[idx[:obj_lvl_3_id]][0].to_i
 
   data << {
-    agency: row[headers[agency.to_i]], #row["Account Description"],
-    #account: row[headers[account.to_i]], #row["Account Description"],
-    fund: row[headers[fund.to_i]], #row["FundDescription"],
-    #unit: row[headers[operating_unit.to_i]],  #row["OperatingUnitDescription"],
-    lob: row[headers[lob.to_i]],  #row["OperatingUnitDescription"],
-    program: row[headers[program_name.to_i]],  #row["OperatingUnitDescription"],
-    key: row[headers[account.to_i]], #row["ProgramName"],
-    value: row[headers[amount.to_i]].gsub('$', '').gsub(',', '').gsub('.00', '') #row["Budget"].to_i
+    # Some data have extra whitespace. Strip 'em all.
+    agency: row[idx[:agency]].strip,
+    fund: row[idx[:fund]].strip,
+    lob: row[idx[:lob]].strip,
+    program: row[idx[:program]].strip,
+    key: row[idx[:key]].strip,
+    # TODO Some of these expenditures are negative. Intentional?
+    value: row[idx[:value]].gsub('$', '').gsub(',', '').gsub('.00', '')
   }
 end
 
-file = File.new("#{file_name}.json" , 'w')
-file.write JSON.pretty_generate(data)
+if options[:fileout]
+  file = File.new(options[:fileout] , 'w')
+  file.write JSON.pretty_generate(data)
+else
+  puts JSON.pretty_generate(data)
+end


### PR DESCRIPTION
`data_to_json.rb` has been updated to act as a command-line script instead of reading from stdin, making it easier to use in other scripts.
Two important changes vs the old: (1) the csv file is opened with utf8bom encoding and (2) csv fields are stripped when writing to json. The output files match the previous version of the script (minus the whitespace strips).

Example using the default args:
```
./data-utilities/data_to_json.rb \
  -i _src/data/fy2017/wichita_2017_adopted_budget.csv \
  -o _src/data/fy2017/wichita_2017_adopted_budget.json
```

Example using caller-specific csv headers mapped to json keys:
```
./data-utilities/data_to_json.rb \
  -i _src/data/fy2017/wichita_2017_adopted_budget.csv \
  -o _src/data/fy2017/wichita_2017_adopted_budget.json \
  --agency=dept_title \
  --fund=org_cost_acct \
  --lob=oca_title \
  --program=obj_lvl_3_title \
  --key=obj_lvl_3_title \
  --value=appropriation_amt
```