### PR TITLE
line item hyperlinks

### DIFF
--- a/_src/fy2017-wichita-budget-tree.jade
+++ b/_src/fy2017-wichita-budget-tree.jade
@@ -298,13 +298,30 @@ script.
         $('table.treemap th:contains(' + tsortcolumn + ') span').addClass(tsortdirection === -1 ? "glyphicon-triangle-bottom" : "glyphicon-triangle-top");
         
         sortTableData(d).forEach(function(value) {
-          $('table.treemap tbody').append("<tr><td>" + value.key + "</td><td>$" + formatNumber(value.value) + "</td></tr>")
+          var anchor = value.values ? 
+            $("<a href></a>")
+              .text(value.key)
+              .data(value)
+              .click(function(e){
+                transition($(this).data());
+                e.preventDefault();
+              }) :
+            $("<span>" + value.key + "</span>");
+            
+          $('table.treemap tbody')
+            .append($("<tr>")
+              .append($("<td>")
+                .append(anchor))
+              .append("<td>$" + formatNumber(value.value) + "</td>"))
         });
       }
   
       //Sort data for the table of values below the d3 visualization
       function sortTableData(d) {
         var values;
+        if (!d.values)
+          return [];
+
         if (tsortcolumn == "Item"){
           values = d.values.sort(function(a, b) {return tsortdirection * (a.key.localeCompare(b.key))});
         } else {


### PR DESCRIPTION
Added hyperlink to line items to allow for drilling down to a sub-category of the budget data.  Implemented by storing a reference to the child data collections in a data-*  attribute on the anchor element.  #13 