### PR TITLE
Globally change http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Chat
 
-Join the Open Wichita Slack room here: http://openwichita-slack.herokuapp.com/. Once there, check out the #openbudget channel for discussion about this project.
+Join the Open Wichita Slack room here: https://openwichita-slack.herokuapp.com/. Once there, check out the #openbudget channel for discussion about this project.
 
 ## Getting Started
 
@@ -79,7 +79,7 @@ in the ``` package.json ``` at the root of this project.
 
 This project is coded with:
 
-- [jade](http://jade-lang.com/)
+- [jade](https://pugjs.org) (now called pug)
 - [Sass](http://sass-lang.com/)
 - [Bootstrap](http://getbootstrap.com/)
 

--- a/_src/_data.json
+++ b/_src/_data.json
@@ -1,7 +1,7 @@
 {
   "globals": {
     "title": "Open Budget: Wichita",
-    "uri": "http://budget.openwichita.com"
+    "uri": "https://budget.openwichita.com"
   },
 
   "index": {

--- a/_src/_layout.jade
+++ b/_src/_layout.jade
@@ -17,10 +17,10 @@ html
       script.
         ga = function() {};
 
-    script(src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js").
-    script(src='http://code.jquery.com/jquery-migrate-1.2.1.js')
-    script(src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js").
-    script(src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.5/d3.min.js").
+    script(src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js").
+    script(src='https://code.jquery.com/jquery-migrate-1.2.1.js')
+    script(src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js").
+    script(src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.4.5/d3.min.js").
 
   body(class='#{slug}')
     #wrapper
@@ -55,7 +55,7 @@ html
     footer#footer
       .container
         .row
-          //-a(rel="license", href="http://creativecommons.org/licenses/by-nc-sa/4.0/")
+          //-a(rel="license", href="https://creativecommons.org/licenses/by-nc-sa/4.0/")
             img(alt="Creative Commons License", style="border-width:0", src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png")
           .col-md-7.col-sm-9
             ul.list-inline
@@ -81,6 +81,6 @@ html
               li
                 a(href="who-we-are.html") About the Project
               li
-                a(href="http://www.meetup.com/openwichita") Get Involved
+                a(href="https://www.meetup.com/openwichita") Get Involved
 
-    link(href='http://fonts.googleapis.com/css?family=Arvo:400,700', rel='stylesheet', type='text/css')
+    link(href='https://fonts.googleapis.com/css?family=Arvo:400,700', rel='stylesheet', type='text/css')

--- a/_src/_who-we-are.jade
+++ b/_src/_who-we-are.jade
@@ -4,10 +4,10 @@ p
 a(href="https://github.com/orgs/openwichita/people") contributors 
 | including coders, community advocates, and city officials. We're looking for ideas and help, so get in touch and join in at our monthly
 | meetups.  We have a monthly in-person meeting (please check 
-a(href='http://www.meetup.com/openwichita/' target='_blank') meetup.com 
+a(href='https://www.meetup.com/openwichita/' target='_blank') meetup.com 
 |for location and time)
 | and on-line virtual meetings on 
-a(href='http://openwichita.com/slack' target='_blank') Slack
+a(href='https://openwichita.com/slack' target='_blank') Slack
 |.
 
 div

--- a/_src/budget-radar.jade
+++ b/_src/budget-radar.jade
@@ -47,7 +47,7 @@
 
 script(src='/js/ramda.min.js', charset='utf-8')
 script(src='/js/check_deps.js', charset='utf-8')
-script(src='http://d3js.org/d3.v3.min.js', charset='utf-8')
+script(src='https://d3js.org/d3.v3.min.js', charset='utf-8')
 script(src="https://d3js.org/d3-collection.v1.min.js", charset='utf-8')
 script(src='/js/palette.js', charset='utf-8')
 script(src='/js/radarChart.js', charset='utf-8')  

--- a/_src/feedback.jade
+++ b/_src/feedback.jade
@@ -19,7 +19,7 @@
           | Who should be part of this discussion?
         p
           | Join us 
-          a(href="http://openwichita.com/slack") in Slack 
+          a(href="https://openwichita.com/slack") in Slack 
           | in the #openbudget channel to give your feedback and ideas!
         p
           | Or you can email: seth@openwichita.com

--- a/_src/fy2017-wichita-budget-tree.jade
+++ b/_src/fy2017-wichita-budget-tree.jade
@@ -99,8 +99,8 @@
         span.glyphicon
     tbody
 
-script(src="http://code.jquery.com/jquery-1.7.2.min.js",charset='utf-8')
-script(src="http://d3js.org/d3.v3.min.js"              ,charset='utf-8')
+script(src="https://code.jquery.com/jquery-1.7.2.min.js",charset='utf-8')
+script(src="https://d3js.org/d3.v3.min.js"              ,charset='utf-8')
 script(src="/js/data.js",charset='utf-8')
 script.
   window.addEventListener('message', function(e) {

--- a/_src/js/old/main2.js
+++ b/_src/js/old/main2.js
@@ -43,7 +43,7 @@ $(function() {
 
     var context = {
 	dataset: "mayor_s_proposed_policy_budget_fy2013-15",
-	siteUrl: "http://openspending.org",
+	siteUrl: "https://openspending.org",
         drilldown: function(node) { // Gets called on node click
 	    // If the node has children we can drill more
 	    if (node.data.node.children.length) {

--- a/_src/js/old/main3.js
+++ b/_src/js/old/main3.js
@@ -86,7 +86,7 @@ $(function() {
 
     var context = {
 	dataset: "mayor_s_proposed_policy_budget_fy2013-15",
-	siteUrl: "http://openspending.org",
+	siteUrl: "https://openspending.org",
         drilldown: function(node) { // Gets called on node click
 	    // If the node has children we can drill more
 	    if (node.data.node.children.length) {

--- a/_src/js/old/main4.js
+++ b/_src/js/old/main4.js
@@ -86,7 +86,7 @@ $(function() {
 
     var context = {
 	dataset: "mayor_s_proposed_policy_budget_fy2013-15",
-	siteUrl: "http://openspending.org",
+	siteUrl: "https://openspending.org",
         drilldown: function(node) { // Gets called on node click
 	    // If the node has children we can drill more
 	    if (node.data.node.children.length) {

--- a/_src/what-we-do.jade
+++ b/_src/what-we-do.jade
@@ -8,7 +8,7 @@
         p(align='right')
           small
             | Image:
-            a(href='http://www.openspending.org/', target='_blank') OpenSpending
+            a(href='https://www.openspending.org/', target='_blank') OpenSpending
 
       != partial("_what-we-do")
 //

--- a/_treemap/treemap-template.jade
+++ b/_treemap/treemap-template.jade
@@ -82,7 +82,7 @@ noscript
   | Please enable JavaScript to view the
   a(href='http://disqus.com/?ref_noscript') comments powered by Disqus.
 
-script(src='http://d3js.org/d3.v3.min.js', charset='utf-8')
+script(src='https://d3js.org/d3.v3.min.js', charset='utf-8')
 script(src='/js/palette.js', charset='utf-8')
 script(src='/js/source.js', charset='utf-8')
 script(src='/js/data.js', charset='utf-8')

--- a/archive/budget.html
+++ b/archive/budget.html
@@ -38,7 +38,7 @@ div.tooltip {
 <body>
 
 <script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://d3js.org/d3.v3.min.js"></script>
 
 <body>
     <h2>Bar Chart</h2>

--- a/archive/circles.html
+++ b/archive/circles.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" type="text/css" href="circles.css">
 
 <body>
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://d3js.org/d3.v3.min.js"></script>
 <script type="text/javascript" charset="utf-8">
   var dataSource = "data/generated/nested_tree.json";
 </script>

--- a/archive/circles_inverted.html
+++ b/archive/circles_inverted.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" type="text/css" href="circles.css">
 
 <body>
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://d3js.org/d3.v3.min.js"></script>
 <script type="text/javascript" charset="utf-8">
   var dataSource = "data/generated/inverted_tree.json";
 </script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      {pattern:"http://d3js.org/d3.v3.min.js"},
+      {pattern:"https://d3js.org/d3.v3.min.js"},
       {pattern:"https://d3js.org/d3-collection.v1.min.js"},
       {pattern:'_src/js/*'},
       {pattern:'_test/**'}


### PR DESCRIPTION
Updated protocols on all links and scripts, except for reference to `discourse.org` and `openwichita.com`.