### PR TITLE
Add GitHub issues link in footer

### DIFF
--- a/_src/_layout.jade
+++ b/_src/_layout.jade
@@ -67,6 +67,10 @@ html
                 br
                 |better understand Wichita's spending and budget process.
                 a(href="https://openwichita.com/slack")  Get Involved.
+                br
+                |Or,
+                a(href="https://github.com/openwichita/openbudgetwichita/issues")  report an issue 
+                |with this page.
 
 
           .col-sm-3.col-md-push-3


### PR DESCRIPTION
Add an "Or, [report an issue](https://github.com/openwichita/openbudgetwichita/issues) with this page." sentence to the page footer. To provide a link to GitHub.