### PR TITLE
Make breadcrumbs accessible

### DIFF
--- a/_src/budget-radar.jade
+++ b/_src/budget-radar.jade
@@ -1,40 +1,4 @@
 .container
-  style.
-    #radar{
-    display:     block;
-    max-width:   100%;
-    margin:      auto;
-    padding-top: 10px;
-    }
-    #breadcrumbs {
-    margin:  0px;
-    padding: 0px;
-    cursor:  pointer;
-    }
-    #table {
-    display:   block;
-    max-width: 100%;
-    margin:    auto;
-    }
-    #tooltip p {
-    margin:  0px;
-    padding: 0px;
-    }
-    .amount {
-    padding: 0px;
-    margin:  0px;
-    font-size:   medium;
-    font-family: "Open Sans", Helvetica, Arial, sans-serif;
-    }
-    .name {
-    padding: 0px;
-    margin:  0px;
-    font-size:   small;
-    font-family: "Open Sans", Helvetica, Arial, sans-serif;
-    }
-    #spacer {
-    height: 30px;
-    }
   .row
     .intro.col-md-8
       h1 Approved Budget Comparison

--- a/_src/css/_visualizations.scss
+++ b/_src/css/_visualizations.scss
@@ -1,0 +1,40 @@
+#radar, #treemap {
+  display:     block;
+  max-width:   100%;
+  margin:      auto;
+  padding-top: 10px;
+}
+#breadcrumbs {
+  margin:  0px;
+  padding: 0px;
+  cursor:  pointer;
+  color: #009DB0;
+}
+.crumb:not(:first-child):before {
+  content: "\00a0>\00a0";
+  color: #333;
+}
+#table {
+  display:   block;
+  max-width: 100%;
+  margin:    auto;
+}
+#tooltip p {
+  margin:  0px;
+  padding: 0px;
+}
+.amount {
+  padding: 0px;
+  margin:  0px;
+  font-size:   medium;
+  font-family: "Open Sans", Helvetica, Arial, sans-serif;
+}
+.name {
+  padding: 0px;
+  margin:  0px;
+  font-size:   small;
+  font-family: "Open Sans", Helvetica, Arial, sans-serif;
+}
+#spacer {
+  height: 30px;
+}

--- a/_src/css/main.scss
+++ b/_src/css/main.scss
@@ -7,6 +7,7 @@
 @import "sections/sections";
 @import "contact";
 @import "timeline";
+@import "visualizations";
 
 @import "treemap"; // D3 Treemap
 @import "flow"; // D3 Sankey diagram

--- a/_src/js/budget-treemap.js
+++ b/_src/js/budget-treemap.js
@@ -303,7 +303,10 @@ ob.display = ob.display || {};
                 .data(ob.data.hierarchy().path(d));
 
             crumbs.enter().append("span")
-              .attr("class", "crumb")
+              .attr({
+                "class": "crumb",
+                tabIndex: 0
+              })
               .on("click", function(clicked, i) {
                 if (clicked == current_node) {
                   /* don't transition if they click on the same data that is already
@@ -318,9 +321,7 @@ ob.display = ob.display || {};
                 }
                 _treemap.transition(clicked, levels, false);
               })
-              .text(function(d, i) {
-                return i > 0 ? ' > ' + d.key : d.key;
-              });
+              .text(d => d.key);
           }
 
           /* set parent links */

--- a/_src/templates/tree-template.jade
+++ b/_src/templates/tree-template.jade
@@ -1,40 +1,4 @@
 .container
-  style.
-    #treemap{
-    display: block;
-    max-width: 100%;
-    margin: auto;
-    padding-top: 10px;
-    }
-    #breadcrumbs {
-    margin: 0px;
-    padding: 0px;
-    cursor:pointer;
-    }
-    #table {
-    display: block;
-    max-width: 100%;
-    margin: auto;
-    }
-    #tooltip p {
-    margin: 0px;
-    padding: 0px;
-    }
-    .amount {
-    padding: 0px;
-    margin: 0px;
-    font-size: medium;
-    font-family: "Open Sans", Helvetica, Arial, sans-serif;
-    }
-    .name {
-    padding: 0px;
-    margin: 0px;
-    font-size: small ;
-    font-family: "Open Sans", Helvetica, Arial, sans-serif;
-    }
-    #spacer {
-    height: 30px;
-    }
   .row
     .intro.col-md-8
       block title


### PR DESCRIPTION
The breadcrumbs in the budget tree are not accessible using the tab key. This change:

* Adds a `tabindex` to each crumb.
* Moves duplicated css from the tree and radar (doesn't matter at the moment) into the page css.
* Colors the crumb text to match link text... I originally switched all the `span`s into links (`a`), but clicking on the crumb would duplicate the entire tree diagram; and since I'm not *that* familiar with d3, I didn't look up how to stop event propagation in the d3 event bindings.