### PR TITLE
Display for non-selected account type

### DIFF
--- a/_src/js/budget-treemap.js
+++ b/_src/js/budget-treemap.js
@@ -392,10 +392,18 @@ ob.display = ob.display || {};
                 elem.attr("class", "item").html(d.key);
               }
               else if (i == 2) {
-                elem.attr("class", "money").html(_format.number(d.data.expense));
-              }
+                if(config.dropdown_choice.Account == "Revenue") {
+                  elem.attr("class", "money").html('n/a*')
+                } else {
+                  elem.attr("class", "money").html(_format.number(d.data.expense));
+                }
+              } 
               else if (i == 3) {
-                elem.attr("class", "money").html(_format.number(d.data.revenue));
+                if(config.dropdown_choice.Account == "Expense") {
+                  elem.attr("class", "money").html('n/a*')
+                } else {
+                   elem.attr("class", "money").html(_format.number(d.data.revenue));   
+                }
               }
               if (i == 0) {
                 var parent_node = d3.select(elem.node().parentNode);

--- a/_src/templates/tree-template.jade
+++ b/_src/templates/tree-template.jade
@@ -16,8 +16,11 @@
   #spacer
   #table(style="margin-bottom: 30px;")
 
-  block datasource
+  .row
+    .col-sm-12
+      p * Switch account setting to view.
 
+  block datasource
 
   section#comments
     .row

--- a/_src/templates/tree-template.jade
+++ b/_src/templates/tree-template.jade
@@ -18,7 +18,7 @@
 
   .row
     .col-sm-12
-      p * Switch account setting to view.
+      p * Change account selection to view.
 
   block datasource
 


### PR DESCRIPTION
Addresses #52 

For non-selected account type, displays "n/a*" instead of 0. Added a note at the bottom of the page instructing the user to select the other account type to see the values. 